### PR TITLE
Bugfixes 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - "--table" key to enable fancy table decorations for network search results. Decorations are disabled by default.
 - `faddr` now can receive more than one ip address to search for.
+- Add indexing to some database fields
 
 ## [0.2.1] - 2022-03-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- "--table" key to enable fancy table decorations for network search results. Decorations are disabled by default.
+- `faddr` now can receive more than one ip address to search for.
+
 ## [0.2.1] - 2022-03-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2022-04-03
+
 ### Added
 
 - "--table" key to enable fancy table decorations for network search results. Decorations are disabled by default.
 - `faddr` now can receive more than one ip address to search for.
 - Add indexing to some database fields
+
+## Fixed
+
+- Now `dabasese.find_network` searches up to `/16`
 
 ## [0.2.1] - 2022-03-28
 

--- a/faddr/__init__.py
+++ b/faddr/__init__.py
@@ -6,7 +6,7 @@ import sys
 from loguru import logger
 from rich.console import Console
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 if os.getenv("FADDR_DEBUG") or any(arg in sys.argv for arg in ("-D", "--debug")):
     LOG_LEVEL = "DEBUG"

--- a/faddr/database.py
+++ b/faddr/database.py
@@ -301,7 +301,6 @@ class Database:
 
         with Session(self.engine) as session:
             for row in session.execute(stmt):
-                # row = list(row).insert(0, query)
                 row = list(row)
                 row.insert(0, query)
                 data = dict(zip(result.headers["full"], row))

--- a/faddr/database.py
+++ b/faddr/database.py
@@ -48,7 +48,7 @@ class Device(Base):  # pylint: disable=too-few-public-methods
     __tablename__ = "device"
 
     id = Column(Integer, primary_key=True)
-    name = Column(String)
+    name = Column(String, index=True)
     path = Column(String)
     source = Column(String)
 
@@ -59,19 +59,19 @@ class Interface(Base):  # pylint: disable=too-few-public-methods
     __tablename__ = "interface"
 
     id = Column(Integer, primary_key=True)
-    name = Column(String)
+    name = Column(String, index=True)
     parent_interface = Column(String)
     unit = Column(String)
     duplex = Column(String)
     speed = Column(String)
-    description = Column(String)
+    description = Column(String, index=True)
     is_disabled = Column(Boolean, default=False)
     encapsulation = Column(String)
     s_vlan = Column(Integer)
     c_vlan = Column(Integer)
-    vrf = Column(String)
-    acl_in = Column(String)
-    acl_out = Column(String)
+    vrf = Column(String, index=True)
+    acl_in = Column(String, index=True)
+    acl_out = Column(String, index=True)
 
     device_id = Column(Integer, ForeignKey("device.id"))
 
@@ -87,7 +87,7 @@ class IP(Base):  # pylint: disable=too-few-public-methods
     exploded = Column(String)
     hostmask = Column(String)
     hosts = Column(Integer)
-    ip = Column(String)
+    ip = Column(String, index=True)
     is_link_local = Column(Boolean, default=False)
     is_loopback = Column(Boolean, default=False)
     is_multicast = Column(Boolean, default=False)
@@ -96,8 +96,8 @@ class IP(Base):  # pylint: disable=too-few-public-methods
     is_unspecified = Column(Boolean, default=False)
     max_prefixlen = Column(Integer)
     netmask = Column(String)
-    network = Column(String)
-    network_address = Column(String)
+    network = Column(String, index=True)
+    network_address = Column(String, index=True)
     num_addresses = Column(Integer)
     prefixlen = Column(Integer)
     version = Column(Integer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "faddr"
-version = "0.2.1"
+version = "0.2.2"
 description = "Tool to parse configuration of network devices such as Juniper routers and store gathered data in database"
 license = "MIT"
 authors = ["Fedor Suchkov <f.suchkov@gmail.com>"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,4 +5,4 @@ from faddr import __version__
 
 def test_version():
     """Test app version."""
-    assert __version__ == "0.2.1"
+    assert __version__ == "0.2.2"


### PR DESCRIPTION
### Added

- "--table" key to enable fancy table decorations for network search results. Decorations are disabled by default.
- `faddr` now can receive more than one ip address to search for.
- Add indexing to some database fields

## Fixed

- Now `dabasese.find_network` searches up to `/16`