### PR TITLE
Removed debug line that was printed even with `FADDR_DEBUG=false`. Up…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2022-05-16
+
+### Fixed
+
+- Removed debug line that was printed even with `FADDR_DEBUG=false`
+
 ## [0.4.0] - 2022-05-15
 
 ### Added

--- a/faddr/__init__.py
+++ b/faddr/__init__.py
@@ -1,4 +1,4 @@
 """Parse network devices' configuration and store in database."""
 
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/faddr/faddr.py
+++ b/faddr/faddr.py
@@ -75,7 +75,6 @@ def main():
 
     # Load settings
     settings = FaddrSettings()
-    print(settings.dict())
     logger.debug(f"Generated settings: {settings.dict()}")
 
     # Parse CMD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "faddr"
-version = "v0.4.0"
+version = "v0.4.1"
 description = "Tool to parse configuration of network devices such as Juniper routers and store gathered data in database"
 license = "MIT"
 authors = ["Fedor Suchkov <f.suchkov@gmail.com>"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,4 +5,4 @@ from faddr import __version__
 
 def test_version():
     """Test app version."""
-    assert __version__ == "0.4.0"
+    assert __version__ == "0.4.1"


### PR DESCRIPTION
…dated CHANGELOG.md and bumped version to 0.4.1